### PR TITLE
Remove Resources from Amplify site-creation-base

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,6 @@ colors:
       color: '#00838f'
     - title: media-color-five
       color: '#00838f'
-resources_name: resources
 
 description: An Isomer site of the Singapore Government
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,5 +13,3 @@ links:
     url: /example-page
   - title: Example Folder
     collection: example-folder
-  - title: Resources
-    resource_room: true

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,6 +10,6 @@ links:
   - title: Contact Us
     url: /contact-us/
   - title: Example Page
-    url: /example-page
+    url: /example-page/
   - title: Example Folder
     collection: example-folder

--- a/index.md
+++ b/index.md
@@ -28,9 +28,5 @@ sections:
         description: About a sentence worth of description here
         button: Button text
         url: /faq/
-    - resources:
-        title: Media
-        subtitle: Learn more
-        button: View More
 ---
 

--- a/pages/example-page.md
+++ b/pages/example-page.md
@@ -1,4 +1,4 @@
 ---
 title: Example Page
-permalink: /example-page
+permalink: /example-page/
 ---

--- a/resources/category/_posts/2019-01-01-test.md
+++ b/resources/category/_posts/2019-01-01-test.md
@@ -1,6 +1,0 @@
----
-layout: post
-title: "Sample post for Category"
-permalink: "/resources/category/test"
----
-Lorem ipsum sit amet

--- a/resources/category/index.html
+++ b/resources/category/index.html
@@ -1,4 +1,0 @@
----
-layout: resources-alt
-title: Category
----

--- a/resources/index.html
+++ b/resources/index.html
@@ -1,4 +1,0 @@
----
-layout: resources
-title: Resources
----


### PR DESCRIPTION
This is the base site that we copy for new sites created with the [Create Amplify Isomer site form](https://form.gov.sg/#!/6274c3623010f000123d0905). @jacksonOGP requested that we remove the Resources page. This is because the name "resources" cannot easily be changed once it has been created, and this is rather annoying for new users.

This PR also reflects a new strategy for single-page permalinks: we will add a trailing slash to the permalink in each page. Since Amplify rewrite rules add a trailing slash when it is missing, this allows us to link to the permalink `/example-page/` with either `/example-page/` or `/example-page`. This strategy simplifies the migration of existing sites, because we only have to update the permalink definition on each page and leave everything that links to it untouched. We have updated the sing-page permalinks in this base repo to be consistent with that strategy.